### PR TITLE
Replace euc_kr decoding codec with cp949

### DIFF
--- a/pet.py
+++ b/pet.py
@@ -415,7 +415,7 @@ class Frame:
 
         self.index, = read_struct(file, '<I')
         for i in range(3):
-            msg = read_fixed_string(file).decode('euc_kr')
+            msg = read_fixed_string(file).decode('cp949')
             self.messages.append(msg)
 
         if total < 2 and self.messages[0] == '':


### PR DESCRIPTION
`euc_kr` cannot fully represent all Korean characters used in PangYa.

`cp949` must be used in all places where Korean characters are used.